### PR TITLE
[FIXED]`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,11 @@ Bundler.require(*Rails.groups)
 
 module Dive23
   class Application < Rails::Application
+
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
config/application.rbにrails generate controller で無駄な helper や assets …を生成しないコードを記述

```
config.generators do |g|
  g.assets     false
  g.helper     false
end
```
