### PR TITLE
[FIXED]＜エラー＞ユーザーを削除しても、紐付いた質問が削除されず、エラーが発生する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,10 @@
 class User < ActiveRecord::Base
-  has_many :questions, dependent: :destroy
   has_many :answers, dependent: :destroy
-  has_many :favorites, dependent: :destroy
   has_many :questions, through: :favorites
+  has_many :favorites, dependent: :destroy
+  has_many :myquestions, class_name: "Question", dependent: :destroy
   has_many :votes, dependent: :destroy
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,


### PR DESCRIPTION
#127 

アソシエーション定義の順番を変えると解消できるという以下の記事を見つけて、has_many :questions, through: :favoritesとhas_many :favorites, dependent: :destroyの順を入れ替えることで解消できました
http://archive.railsforum.com/viewtopic.php?id=17605

加えてuser.questionsで取れる情報が「自分のお気に入り質問」及び「自分が投稿した質問」の両方を定義しているため、「自分が投稿した質問」の定義はhas_many :myquestions, class_name: "Question", dependent: :destroyと変更しました。唯一この定義が利用される箇所は、自分の投稿した質問の箇所ですが、@questions = Question.where(user_id: @user.id)で取得されているので、変更はしましたが、特にアプリケーション上で影響はありません。